### PR TITLE
Fix resetbadge command

### DIFF
--- a/ressources/text/commands/resetBadgeCommand.json
+++ b/ressources/text/commands/resetBadgeCommand.json
@@ -5,7 +5,7 @@
                   "descReset": "Les badges de {player} ont été réinitialisés."
             },
             "en": {
-                  "giveSuccess": "{pseudo}, finished!",
+                  "resetSuccess": "{pseudo}, finished!",
                   "descReset": "{player}'s badges are now gone."
             }
       }


### PR DESCRIPTION
Fix d'un problème de nom de variable qui faisait crash le bot lors de l'exécution de la commande en anglais. #176 