### PR TITLE
Changement des permission lorsqu'on est en prison.

### DIFF
--- a/src/commands/guild/GuildAddCommand.js
+++ b/src/commands/guild/GuildAddCommand.js
@@ -18,7 +18,7 @@ const GuildAddCommand = async (language, message, args) => {
 			message,
 			language,
 			PERMISSION.ROLE.ALL,
-			[EFFECT.BABY, EFFECT.DEAD],
+			[EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED],
 			entity
 		)) !== true
 	) {

--- a/src/commands/guild/GuildCreateCommand.js
+++ b/src/commands/guild/GuildCreateCommand.js
@@ -16,7 +16,7 @@ const GuildCreateCommand = async (language, message, args) => {
 			message,
 			language,
 			PERMISSION.ROLE.ALL,
-			[EFFECT.BABY, EFFECT.DEAD],
+			[EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED],
 			entity,
 			GUILD.REQUIRED_LEVEL
 		)) !== true

--- a/src/commands/guild/GuildDailyCommand.js
+++ b/src/commands/guild/GuildDailyCommand.js
@@ -12,7 +12,7 @@ const GuildDailyCommand = async (language, message, args, forcedReward) => {
 
 	[entity] = await Entities.getOrRegister(message.author.id);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], entity, GUILD.REQUIRED_LEVEL)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], entity, GUILD.REQUIRED_LEVEL)) !== true) {
 		return;
 	}
 

--- a/src/commands/guild/GuildElderCommand.js
+++ b/src/commands/guild/GuildElderCommand.js
@@ -18,7 +18,7 @@ const GuildElderCommand = async (language, message, args) => {
 			message,
 			language,
 			PERMISSION.ROLE.ALL,
-			[EFFECT.BABY, EFFECT.DEAD],
+			[EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED],
 			entity
 		)) !== true
 	) {

--- a/src/commands/guild/GuildShelterCommand.js
+++ b/src/commands/guild/GuildShelterCommand.js
@@ -12,7 +12,7 @@ const GuildShelterCommand = async (language, message, args) => {
 			message,
 			language,
 			PERMISSION.ROLE.ALL,
-			[EFFECT.BABY, EFFECT.DEAD],
+			[EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED],
 			entity
 		)) !== true
 	) {

--- a/src/commands/guild/GuildStorageCommand.js
+++ b/src/commands/guild/GuildStorageCommand.js
@@ -12,7 +12,7 @@ const GuildStorageCommand = async (language, message, args) => {
 			message,
 			language,
 			PERMISSION.ROLE.ALL,
-			[EFFECT.BABY, EFFECT.DEAD],
+			[EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED],
 			entity
 		)) !== true
 	) {

--- a/src/commands/pets/PetFreeCommand.js
+++ b/src/commands/pets/PetFreeCommand.js
@@ -15,7 +15,7 @@ const PetFreeCommand = async function (language, message, args) {
 	}
 
 	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL,
-		[EFFECT.BABY, EFFECT.LOCKED, EFFECT.LOCKED], entity)) !== true) {
+		[EFFECT.BABY, EFFECT.LOCKED, EFFECT.DEAD], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/pets/PetFreeCommand.js
+++ b/src/commands/pets/PetFreeCommand.js
@@ -15,7 +15,7 @@ const PetFreeCommand = async function (language, message, args) {
 	}
 
 	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL,
-		[EFFECT.BABY], entity)) !== true) {
+		[EFFECT.BABY, EFFECT.LOCKED, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/pets/PetNicknameCommand.js
+++ b/src/commands/pets/PetNicknameCommand.js
@@ -8,7 +8,7 @@ const PetNicknameCommand = async function (language, message, args) {
 	const [entity] = await Entities.getOrRegister(message.author.id);
 
 	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL,
-		[EFFECT.BABY], entity)) !== true) {
+		[EFFECT.BABY, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/pets/PetSellCommand.js
+++ b/src/commands/pets/PetSellCommand.js
@@ -14,7 +14,7 @@ const PetSellCommand = async function (language, message, args) {
 
 	const translations = JsonReader.commands.petSell.getTranslation(language);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/pets/PetTradeCommand.js
+++ b/src/commands/pets/PetTradeCommand.js
@@ -8,7 +8,7 @@ const PetTradeCommand = async function (language, message, args) {
 	let [trader1] = await Entities.getOrRegister(message.author.id);
 
 	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL,
-		[EFFECT.BABY], trader1)) !== true) {
+		[EFFECT.BABY, EFFECT.LOCKED], trader1)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/pets/PetTransferCommand.js
+++ b/src/commands/pets/PetTransferCommand.js
@@ -9,7 +9,7 @@ const PetTransferCommand = async function (language, message, args) {
 	const pPet = entity.Player.Pet;
 
 	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL,
-		[EFFECT.BABY], entity)) !== true) {
+		[EFFECT.BABY, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/player/DailyCommand.js
+++ b/src/commands/player/DailyCommand.js
@@ -5,7 +5,7 @@
  */
 const DailyCommand = async function (language, message) {
 	const [entity] = await Entities.getOrRegister(message.author.id);
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 

--- a/src/commands/player/DrinkCommand.js
+++ b/src/commands/player/DrinkCommand.js
@@ -5,7 +5,7 @@
  */
 const DrinkCommand = async function (language, message) {
 	const [entity] = await Entities.getOrRegister(message.author.id);
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/player/FightCommand.js
+++ b/src/commands/player/FightCommand.js
@@ -11,7 +11,7 @@ const FightCommand = async function (language, message, args, friendly = false) 
 	let attacker;
 	[attacker] = await Entities.getOrRegister(message.author.id);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], attacker)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], attacker)) !== true) {
 		return;
 	}
 

--- a/src/commands/player/InventoryCommand.js
+++ b/src/commands/player/InventoryCommand.js
@@ -10,7 +10,7 @@ const InventoryCommand = async (language, message, args) => {
 		[entity] = await Entities.getOrRegister(message.author.id);
 	}
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 

--- a/src/commands/player/ReportCommand.js
+++ b/src/commands/player/ReportCommand.js
@@ -11,7 +11,7 @@ const Maps = require('../../core/Maps')
 const ReportCommand = async function (language, message, args, forceSpecificEvent = -1) {
 	const [entity] = await Entities.getOrRegister(message.author.id);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.DEAD], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.DEAD, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/player/SellCommand.js
+++ b/src/commands/player/SellCommand.js
@@ -7,7 +7,7 @@
 const SellCommand = async (language, message, args) => {
 	let [entity] = await Entities.getOrRegister(message.author.id);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {

--- a/src/commands/player/SwitchCommand.js
+++ b/src/commands/player/SwitchCommand.js
@@ -9,7 +9,7 @@ const moment = require("moment");
 const SwitchCommand = async (language, message, args) => {
 	const [entity] = await Entities.getOrRegister(message.author.id);
 
-	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD], entity)) !== true) {
+	if ((await canPerformCommand(message, language, PERMISSION.ROLE.ALL, [EFFECT.BABY, EFFECT.DEAD, EFFECT.LOCKED], entity)) !== true) {
 		return;
 	}
 	if (await sendBlockedError(message.author, message.channel, language)) {


### PR DESCRIPTION
Pour contribuer au ticket #368 . Seul les commandes normalement accesible en prison et les commandes importantes pour un chef de guild seront désormais accessible en prison. N'hésitait pas a revew le code.