### PR TITLE
Add "d" alias for daily command

### DIFF
--- a/src/commands/player/DailyCommand.js
+++ b/src/commands/player/DailyCommand.js
@@ -4,7 +4,7 @@ const Maps = require("../../core/Maps");
 
 module.exports.commandInfo = {
 	name: "daily",
-	aliases: ["da"],
+	aliases: ["d", "da"],
 	disallowEffects: [EFFECT.BABY, EFFECT.DEAD]
 };
 


### PR DESCRIPTION
"d" is currently available as a command alias (no other command uses it) and is shorter than "da" (current alias for daily command).
This commit thus adds "d" as an alias for the daily command for conveniency.