### PR TITLE
refactor: replace deprecated String.prototype.substr()

### DIFF
--- a/src/core/Command.js
+++ b/src/core/Command.js
@@ -197,7 +197,7 @@ class Command {
 	 * @return {String}
 	 */
 	static getUsedPrefix(message, prefix) {
-		return message.content.substr(0, prefix.length);
+		return message.content.slice(0, prefix.length);
 	}
 
 	/**
@@ -366,7 +366,7 @@ class Command {
 
 		BlockingUtils.spamBlockPlayer(message.author.id);
 
-		log(message.author.id + " executed in server " + message.guild.id + ": " + message.content.substr(1));
+		log(message.author.id + " executed in server " + message.guild.id + ": " + message.content.slice(1));
 		await command.execute(message, language, args);
 	}
 }

--- a/src/core/models/Potion.ts
+++ b/src/core/models/Potion.ts
@@ -26,7 +26,7 @@ export class Potion extends SupportItemModel {
 	}
 
 	public getSimplePotionName(language: string): string {
-		return this.getName(language).substr(this.getName(language).indexOf(" ") + 1)
+		return this.getName(language).slice(this.getName(language).indexOf(" ") + 1)
 			.replace(/\*\*/g, "");
 	}
 


### PR DESCRIPTION
[String.prototype.substr()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/substr) is deprecated so we replace it with [String.prototype.slice()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/slice) which works similarily but isn't deprecated.
.substr() probably isn't going away anytime soon but the change is trivial so it doesn't hurt to do it.