### PR TITLE
Fix #2282

### DIFF
--- a/src/core/fights/FightController.ts
+++ b/src/core/fights/FightController.ts
@@ -245,6 +245,12 @@ export class FightController {
 			await this._fightView.displayWeatherStatus(this.weather.getWeatherEmote(), weatherMessage);
 		}
 
+		// End the fight if the weather drained the last energy points of a fighter
+		if (this.hadEnded()) {
+			await this.endFight();
+			return;
+		}
+
 		if (this.overtimeBehavior === FightOvertimeBehavior.INCREASE_DAMAGE_PVE && this.turn >= FightConstants.MAX_TURNS) {
 			this.increaseDamagesPve(this.turn);
 		}


### PR DESCRIPTION
Un oversight qui n'aurait pas dû y être à la base. Sans le vouloir, j'avais créé un bug avec la météo qui n'achevait pas le joueur en retirant une condition de la fonction `prepareNextTurn`. Ceci est corrigé en rajoutant à nouveau dans la fonction la condition suivante:
```ts
if (this.hadEnded()) {
	await this.endFight();
	return;
}
```