### PR TITLE
Hotfix #2347

### DIFF
--- a/resources/text/maplinks/84.json
+++ b/resources/text/maplinks/84.json
@@ -1,0 +1,5 @@
+{
+	"startMap": 32,
+	"endMap": 29,
+	"tripDuration": 60
+}


### PR DESCRIPTION
L'event de Noël ne redirigeait plus vers la salle de réception vu que la maplink 84 a été supprimée. Elle a été remise à nouveau.