### PR TITLE
Fix #2351

### DIFF
--- a/resources/text/events/64.json
+++ b/resources/text/events/64.json
@@ -12,7 +12,8 @@
 					"to": 31
 				}
 			},
-			"oncePer": "year"
+			"oncePer": "year",
+			"mapAttributes": ["continent1"]
 		}
 	],
 	"translations": {


### PR DESCRIPTION
L'event de l'invitation de Noël a dû être restreint au continent principal uniquement pour éviter de faire gaspiller un trajet sur l'île (notamment à l'arrivée à la plage noire).