### PR TITLE
Fix commandes inconnues dans /help #2866

### DIFF
--- a/Lang/fr/commands.json
+++ b/Lang/fr/commands.json
@@ -237,9 +237,6 @@
       "PET_SELL": {
         "description": "Permet de vendre un familier. Les conditions suivantes s'appliquent : \n - le prix de vente doit être être supérieur à `{{petSellMinPrice}}{emote:unitValues.money}` et inférieur à `{{petSellMaxPrice}}{emote:unitValues.money}`. \n- Le vendeur ne gagnera pas d'argent lors de la transaction, mais de l'expérience de guilde. \n- Le vendeur et l'acheteur ne peuvent pas faire partie de la même guilde."
       },
-      "PET_TRADE": {
-        "description": "Propose un échange de vos animaux avec la personne mentionnée."
-      },
       "PET_TRANSFER": {
         "description": "Permet de transférer un familier depuis ou vers la guilde. Si aucun numéro n'est fourni, le familier de votre inventaire sera déplacé vers le refuge de la guilde. Sinon, il sera échangé avec celui de la guilde dont la position correspond au numéro donné."
       },

--- a/Lib/src/constants/HelpConstants.ts
+++ b/Lib/src/constants/HelpConstants.ts
@@ -141,7 +141,7 @@ export abstract class HelpConstants {
 		GUILD_TOP:
 			{
 				EMOTE: ":mirror_ball:",
-				NAME: "top guilds",
+				NAME: "top guild",
 				CATEGORY: "guild"
 			},
 		INVENTORY:

--- a/Lib/src/constants/HelpConstants.ts
+++ b/Lib/src/constants/HelpConstants.ts
@@ -59,7 +59,6 @@ export abstract class HelpConstants {
 		GUILD_SHELTER: ["guildshelter", "shelter", "pets", "animals", "gshelter", "gpets", "ganimals", "guildpets", "guildanimals",
 			"guildanimale", "guildanimal", "sh", "abris", "aubergeanimal", "familiers", "guildeshelter", "abrideguilde",
 			"abriguilde", "abrideguild", "abriguild", "abrisdeguilde", "abrisguilde", "abrisdeguild", "abrisguild"],
-		PET_TRADE: ["pettrade", "ptrade", "echangepet", "familiertrade", "fechange", "echangeanimal", "echangeanimale"],
 		PET_FEED: ["petfeed", "feed", "pf", "pfeed", "feedp", "feedpet", "fp"],
 		PET_SELL: ["petsell", "psell", "vendrepet", "ventepet", "vendreanimal", "venteaniaml", "vendreanimale", "venteanimale", "vendreanimales", "venteanimales", "venteanimaux", "vendreanimaux"],
 		CLASSES_INFO: ["classinfo", "classInfo", "cs", "classesstats", "classcompare", "classestats", "classtats", "classstat", "statistiquesclass",
@@ -299,12 +298,6 @@ export abstract class HelpConstants {
 				EMOTE: ":park:",
 				NAME: "guildshelter",
 				CATEGORY: "guild"
-			},
-		PET_TRADE:
-			{
-				EMOTE: ":scales:",
-				NAME: "pettrade",
-				CATEGORY: "pet"
 			},
 		PET_FEED:
 			{


### PR DESCRIPTION
> ~~Notez que les textes dans l'i18n n'ont pas encore été retirés pour /pettrade dans /help, par peur que ça casse toute l'i18n.~~ Le texte a été retiré dans la version française.