### PR TITLE
Fix(fight): Safeguard user ID check in fight action collector

### DIFF
--- a/Discord/src/messages/DraftbotActionChooseCachedMessage.ts
+++ b/Discord/src/messages/DraftbotActionChooseCachedMessage.ts
@@ -65,8 +65,23 @@ export class DraftbotActionChooseCachedMessage extends DraftbotCachedMessage<Rea
 		const buttonCollector = msg!.createMessageComponentCollector({
 			time: packet.endTime - Date.now()
 		});
+
+		let expectedFighterId: string;
+		if (context.discord?.user) {
+			expectedFighterId = context.discord.user;
+		}
+		else {
+			// TODO: Add proper logging if DraftBotLogger is available
+			console.error("Error: context.discord.user is null or undefined in DraftbotActionChooseCachedMessage.ts");
+			expectedFighterId = "undefined"; // Prevent accidental interaction processing
+		}
+		// TODO: Add proper logging if DraftBotLogger is available
+		// console.log(`expectedFighterId: ${expectedFighterId}`);
+
 		buttonCollector.on("collect", async (buttonInteraction: ButtonInteraction) => {
-			if (buttonInteraction.user.id !== context.discord?.user) {
+			// TODO: Add proper logging if DraftBotLogger is available
+			console.log(`Fight Action Click: Clicker: ${buttonInteraction.user.id}, Expected: ${expectedFighterId}`);
+			if (buttonInteraction.user.id !== expectedFighterId) {
 				await sendInteractionNotForYou(buttonInteraction.user, buttonInteraction, lng);
 				return;
 			}


### PR DESCRIPTION
This commit addresses an issue where a fighter could be blocked from choosing an attack if another player opens the shop in the same channel.

The primary change is in `Discord/src/messages/DraftbotActionChooseCachedMessage.ts`:
- The fighter's Discord ID (`context.discord.user`) is now stored in a local variable (`expectedFighterId`) when the action choice collector is created.
- The collector's filter now uses this `expectedFighterId` for checking `buttonInteraction.user.id`. This ensures the comparison is against the correct user ID from the time of collector creation, preventing potential issues if the `context` object was perceived to be mutable or incorrect at the time of the check.
- Added a console log for diagnostic purposes to show the clicker's ID and the expected fighter's ID during the interaction.

This aims to prevent the "interaction not for you" error that the fighter was incorrectly receiving.